### PR TITLE
Update printer.cfg to fix PRINT_START macro

### DIFF
--- a/firmware/Klipper/printer.cfg
+++ b/firmware/Klipper/printer.cfg
@@ -521,9 +521,7 @@ gcode:
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
     G32                            ; home all axes
-    QUAD_GANTRY_LEVEL
-    G1 Z20 F3000                   ; move nozzle away from bed
-   
+    G1 Z20 F3000                   ; move nozzle away from bed 
 
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice


### PR DESCRIPTION
Removed QUAD_GANTRY_LEVEL call from PRINT_START as it's already triggered by G32