### PR TITLE
Add commented section for UART0 RESTART_METHOD

### DIFF
--- a/firmware/Klipper/printer.cfg
+++ b/firmware/Klipper/printer.cfg
@@ -32,6 +32,9 @@ serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_230032000851363131363530-if00
 #serial: /dev/ttyAMA0
 ##--------------------------------------------------------------------
 
+## Uncomment below if you're using the Raspberry uart0 to communicate with Spider
+#restart_method: command
+
 [printer]
 kinematics: corexy
 max_velocity: 300  


### PR DESCRIPTION
For those using RPi UART0, this ensures klipper reboots the MCU correctly.