### PR TITLE
updated printer.cfg print_end

### DIFF
--- a/firmware/Klipper/printer.cfg
+++ b/firmware/Klipper/printer.cfg
@@ -530,7 +530,7 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-10.0 F3600                ; retract filament
+    G1 E-1.0 F3600                 ; retract filament
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS


### PR DESCRIPTION
Changed the retract in `print_end` from -10mm to -1mm.  Most all Voron printers are direct drive now and 10mm retract is ok for bowden setups, but way too much for direct drive.  10mm retracts on print_end are causing jamming issues on many users brand new machines.