### PR TITLE
Add modified printer.cfg for Spider version 2.2

### DIFF
--- a/firmware/Klipper/README.md
+++ b/firmware/Klipper/README.md
@@ -4,6 +4,8 @@
 
 This in folder, there a `printer.cfg` file, this is an example Klipper configuration file for VORON2.4 machine. It is not copy-paste available config, you need to adjust the items in file, please read the file carefully, especially the first lines in the file.
 
+When using the Fysetc Spider version 2.2 or higher, please use the file `printer_v2.2.cfg` and rename it to `printer.cfg`. Functionally both example configs are the same, except for updated heater bed and fan pins.
+
 ## Connect RPI UART
 
 Please follow instruction here([github](https://github.com/FYSETC/FYSETC-SPIDER/blob/main/firmware/Klipper/Connect%20RPI%20uart.md) [gitee](https://gitee.com/fysetc/FYSETC-SPIDER/blob/main/firmware/Klipper/Connect%20RPI%20uart.md)).

--- a/firmware/Klipper/printer_v2.2.cfg
+++ b/firmware/Klipper/printer_v2.2.cfg
@@ -1,0 +1,550 @@
+# This file contains common pin mappings for the Fysetc Spider board.
+# To use this config, the firmware should be compiled for the STM32F446.
+# When calling "menuconfig", enable "extra low-level configuration setup"
+# and select the "12MHz crystal" as clock reference
+# For flashing, write the compiled klipper.bin to memory location 0x08000000
+
+# See docs/Config_Reference.md for a description of parameters.
+
+## Voron Design VORON2 250/300/350mm Spider TMC2209 UART config
+
+## *** THINGS TO CHANGE/CHECK: ***
+## MCU paths							[mcu] section
+## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Z Endstop Switch location			[safe_z_home] section
+## Homing end position				[gcode_macro G32] section
+## Z Endstop Switch  offset for Z0		[stepper_z] section
+## Probe points							[quad_gantry_level] section
+## Min & Max gantry corner postions		[quad_gantry_level] section
+## PID tune								[extruder] and [heater_bed] sections
+## Fine tune E steps					[extruder] section
+
+[mcu]
+## Uncomment below if you're using the Raspberry uart0 to communicate with Spider
+#restart_method: command
+
+##  You need to select 'Communication interface' to USB in 'make menuconfig'
+##  when you compile Klipper for Spider
+##	Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_230032000851363131363530-if00
+##	If you want to use the Raspberry uart0 to communicate with Spider,
+##  you need to select 'Communication interface' to 'Serial (on USART1 PA10/PA9)'
+##  in 'make menuconfig' when you compile klipper and set the serial as below
+##--------------------------------------------------------------------
+#serial: /dev/ttyAMA0
+##--------------------------------------------------------------------
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 3000			        #Max 4000
+max_z_velocity: 15			#Max 15 for 12V TMC Drivers, can increase for 24V
+max_z_accel: 350
+square_corner_velocity: 5.0
+
+#####################################################################
+#      X/Y Stepper Settings
+#####################################################################
+
+[stepper_x]
+##	Connected to X-MOT (B Motor)
+step_pin: PE11
+dir_pin: !PE10
+enable_pin: !PE9
+rotation_distance: 40
+microsteps: 16
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+endstop_pin: ^PB14
+position_min: 0
+
+##--------------------------------------------------------------------
+
+##	Uncomment below for 250mm build
+#position_endstop: 250
+#position_max: 250
+
+##	Uncomment for 300mm build
+#position_endstop: 300
+#position_max: 300
+
+##	Uncomment for 350mm build
+#position_endstop: 350
+#position_max: 350
+
+##--------------------------------------------------------------------
+homing_speed: 25   #Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+##	Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_x]
+uart_pin: PE7
+interpolate: True
+run_current: 0.7
+hold_current: 0.4
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+[stepper_y]
+##	Connected to Y-MOT (A Motor)
+step_pin: PD8
+dir_pin: !PB12
+enable_pin: !PD9
+rotation_distance: 40
+microsteps: 16
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+endstop_pin: ^PB13
+position_min: 0
+##--------------------------------------------------------------------
+
+##	Uncomment for 250mm build
+#position_endstop: 250
+#position_max: 250
+
+##	Uncomment for 300mm build
+#position_endstop: 300
+#position_max: 300
+
+##	Uncomment for 350mm build
+#position_endstop: 350
+#position_max: 350
+
+##--------------------------------------------------------------------
+homing_speed: 25  #Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+##	Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_y]
+uart_pin: PE15
+interpolate: True
+run_current: 0.7
+hold_current: 0.4
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+#####################################################################
+#   Z Stepper Settings
+#####################################################################
+
+## In Z-MOT Position
+## Z0 Stepper - Front Left
+[stepper_z]
+step_pin: PD14
+dir_pin: !PD13
+enable_pin: !PD15
+rotation_distance: 40
+gear_ratio: 80:16
+microsteps: 16
+##  In Z- Position
+endstop_pin: ^PA0
+##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
+##  (+) value = endstop above Z0, (-) value = endstop below
+##	Increasing position_endstop brings nozzle closer to the bed
+##  After you run Z_ENDSTOP_CALIBRATE, position_endstop will be stored at the very end of your config
+position_endstop: -0.5
+##--------------------------------------------------------------------
+
+##	Uncomment below for 250mm build
+#position_max: 240
+
+##	Uncomment below for 300mm build
+#position_max: 290
+
+##	Uncomment below for 350mm build
+#position_max: 340
+
+##--------------------------------------------------------------------
+position_min: -5
+homing_speed: 8
+second_homing_speed: 3
+homing_retract_dist: 3
+
+##	Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_z]
+uart_pin: PD10
+uart_address: 0
+interpolate: True
+run_current: 0.7
+hold_current: 0.4
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+##	In E1-MOT Position
+##	Z1 Stepper - Rear Left
+[stepper_z1]
+step_pin: PE6
+dir_pin: PC13
+enable_pin: !PE5
+rotation_distance: 40
+gear_ratio: 80:16
+microsteps: 16
+
+##	Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_z1]
+uart_pin: PC14
+interpolate: True
+run_current: 0.7
+hold_current: 0.4
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+##	In E2-MOT Position
+##	Z2 Stepper - Rear Right
+[stepper_z2]
+step_pin: PE2
+dir_pin: !PE4
+enable_pin: !PE3
+rotation_distance: 40
+gear_ratio: 80:16
+microsteps: 16
+
+##	Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_z2]
+uart_pin: PC15
+interpolate: true
+run_current: 0.7
+hold_current: 0.4
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+##	In E3-MOT Position
+##	Z3 Stepper - Front Right
+[stepper_z3]
+step_pin: PD12
+dir_pin: PC4
+enable_pin: !PE8
+rotation_distance: 40
+gear_ratio: 80:16
+microsteps: 16
+
+[tmc2209 stepper_z3]
+uart_pin: PA15
+interpolate: true
+run_current: 0.7
+hold_current: 0.4
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+#####################################################################
+#   Extruder
+#####################################################################
+
+##	In E0-MOT Position
+[extruder]
+step_pin: PD5
+dir_pin: !PD6
+enable_pin: !PD4
+
+##	Update value below when you perform extruder calibration
+##	If you ask for 100mm of filament, but in reality it is 98mm:
+##	rotation_distance = <previous_rotation_distance> * <actual_extrude_distance> / 100
+##  22.6789511 is a good starting point
+rotation_distance: 22.6789511	#Bondtech 5mm Drive Gears
+##	Update Gear Ratio depending on your Extruder Type
+##	Use 50:17 for Afterburner/Clockwork (BMG Gear Ratio)
+##	Use 80:20 for M4, M3.1
+gear_ratio: 50:17				#BMG Gear Ratio
+microsteps: 16
+full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+##      In E0 OUT Position
+heater_pin: PB15
+##	Validate the following thermistor type to make sure it is correct
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC0 # TE0 Position
+min_temp: 10
+max_temp: 270
+max_power: 1.0
+min_extrude_temp: 170
+control = pid
+pid_kp = 26.213
+pid_ki = 1.304
+pid_kd = 131.721
+##	Try to keep pressure_advance below 1.0
+pressure_advance: 0.05
+##	Default is 0.040, leave stock
+pressure_advance_smooth_time: 0.040
+
+##	In E0-MOT Position
+##	Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 extruder]
+uart_pin: PD7
+interpolate: false
+run_current: 0.5
+hold_current: 0.2
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+#####################################################################
+#   Bed Heater
+#####################################################################
+[heater_bed]
+##	SSR Pin - In BED OUT position
+heater_pin: PB4
+sensor_type: NTC 100K beta 3950
+sensor_pin: PB0 # TB Position
+##	Adjust Max Power so your heater doesn't warp your bed
+max_power: 0.6
+min_temp: 0
+max_temp: 120
+control: pid
+pid_kp: 58.437
+pid_ki: 2.347
+pid_kd: 363.769
+
+#####################################################################
+#	Probe
+#####################################################################
+
+[probe]
+##	Inductive Probe - If you use this section , please comment the [bltouch] section
+##	This probe is not used for Z height, only Quad Gantry Leveling
+##	In Z+ position
+##	If your probe is NC instead of NO, add change pin to ^PA3
+pin: ^!PA3
+x_offset: 0
+y_offset: 25.0
+z_offset: 0
+speed: 10.0
+samples: 3
+samples_result: median
+sample_retract_dist: 3.0
+samples_tolerance: 0.006
+samples_tolerance_retries: 3
+
+#####################################################################
+#	Bltouch
+#####################################################################
+
+#[bltouch]
+##	Bltouch - If you use this section , please comment the [probe] section
+##	More infomation at : https://www.klipper3d.org/BLTouch.html
+##	This bltouch is not used for Z height, only Quad Gantry Leveling
+##	In Z+ Position
+#sensor_pin: PA0
+##	In Y+ Position
+#control_pin: PA2
+#x_offset: 0
+#y_offset: 25.0
+#z_offset: 0
+#speed: 10.0
+#samples: 3
+#samples_result: median
+#sample_retract_dist: 3.0
+#samples_tolerance: 0.006
+#samples_tolerance_retries: 3
+
+#####################################################################
+#	Fan Control
+#####################################################################
+
+[heater_fan hotend_fan]
+##	Hotend Fan - FAN0 Connector
+pin: PA13
+max_power: 1.0
+kick_start_time: 0.5
+heater: extruder
+heater_temp: 50.0
+##	If you are experiencing back flow, you can reduce fan_speed
+#fan_speed: 1.0
+
+[fan]
+##	Print Cooling Fan - FAN1 Connector
+pin: PA14
+max_power: 0.4
+kick_start_time: 0.5
+##	Depending on your fan, you may need to increase this value
+##	if your fan will not start. Can change cycle_time (increase)
+##	if your fan is not able to slow down effectively
+off_below: 0.10
+
+[heater_fan controller_fan]
+##	Controller fan - FAN2 Connector
+pin: PB2
+kick_start_time: 0.5
+heater: heater_bed
+heater_temp: 45.0
+
+#[heater_fan exhaust_fan]
+##  Exhaust fan - In E2 OUT Positon
+#pin: PB3
+#max_power: 1.0
+#shutdown_speed: 0.0
+#kick_start_time: 5.0
+#heater: heater_bed
+#heater_temp: 60
+#fan_speed: 1.0
+
+#####################################################################
+#	LED Control
+#####################################################################
+
+#[output_pin caselight ]
+##  Chamber Lighting - In 5V-RGB Position
+#pin: PD3
+#pwm: true
+#shutdown_value: 0
+#value:100
+#cycle_time: 0.01
+
+#####################################################################
+#	Homing and Gantry Adjustment Routines
+#####################################################################
+
+[idle_timeout]
+timeout: 1800
+
+[safe_z_home]
+##	XY Location of the Z Endstop Switch
+##	Update -10,-10 to the XY coordinates of your endstop pin
+##	(such as 157,305) after going through Z Endstop Pin
+##	Location Definition step.
+home_xy_position:-10,-10
+speed:100
+z_hop:10
+
+[quad_gantry_level]
+##	Use QUAD_GANTRY_LEVEL to level a gantry.
+##	Min & Max gantry corners - measure from nozzle at MIN (0,0) and
+##	MAX (250, 250), (300,300), or (350,350) depending on your printer size
+##	to respective belt positions
+
+#--------------------------------------------------------------------
+##	Gantry Corners for 250mm Build
+##	Uncomment for 250mm build
+#gantry_corners:
+#	-60,-10
+#	310, 320
+##	Probe points
+#points:
+#	50,25
+#	50,175
+#	200,175
+#	200,25
+
+##	Gantry Corners for 300mm Build
+##	Uncomment for 300mm build
+#gantry_corners:
+#	-60,-10
+#	360,370
+##	Probe points
+#points:
+#	50,25
+#	50,225
+#	250,225
+#	250,25
+
+##	Gantry Corners for 350mm Build
+##	Uncomment for 350mm build
+#gantry_corners:
+#	-60,-10
+#	410,420
+##	Probe points
+#points:
+#	50,25
+#	50,275
+#	300,275
+#	300,25
+
+#--------------------------------------------------------------------
+speed: 100
+horizontal_move_z: 10
+retries: 5
+retry_tolerance: 0.0075
+max_adjust: 10
+
+#####################################################################
+#	Displays
+#####################################################################
+
+#--------------------------------------------------------------------
+
+[display]
+#	mini12864 LCD Display
+lcd_type: uc1701
+cs_pin: PC11
+a0_pin: PD2
+rst_pin: PC10
+encoder_pins: ^PC6,^PC7
+click_pin: ^!PA8
+contrast: 63
+#spi_bus: spi1
+spi_software_mosi_pin: PA7
+spi_software_miso_pin: PA6
+spi_software_sclk_pin: PA5
+
+[neopixel fysetc_mini12864]
+#	To control Neopixel RGB in mini12864 display
+pin: PC12
+chain_count: 3
+initial_RED: 0.1
+initial_GREEN: 0.5
+initial_BLUE: 0.0
+color_order: RGB
+
+#	Set RGB values on boot up for each Neopixel.
+#	Index 1 = display, Index 2 and 3 = Knob
+[delayed_gcode setdisplayneopixel]
+initial_duration: 1
+gcode:
+        SET_LED LED=fysetc_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0
+        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0
+        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3
+
+#--------------------------------------------------------------------
+
+
+#####################################################################
+#	Macros
+#####################################################################
+
+[gcode_macro G32]
+gcode:
+    BED_MESH_CLEAR
+    G28
+    QUAD_GANTRY_LEVEL
+    G28
+    ##	Uncomment for for your size printer:
+    #--------------------------------------------------------------------
+    ##	Uncomment for 250mm build
+    #G0 X125 Y125 Z30 F3600
+
+    ##	Uncomment for 300 build
+    #G0 X150 Y150 Z30 F3600
+
+    ##	Uncomment for 350mm build
+    #G0 X175 Y175 Z30 F3600
+    #--------------------------------------------------------------------
+
+[gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+gcode:
+    G32                            ; home all axes
+    G1 Z20 F3000                   ; move nozzle away from bed
+
+[gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+gcode:
+    M400                           ; wait for buffer to clear
+    G92 E0                         ; zero the extruder
+    G1 E-1.0 F3600                 ; retract filament
+    G91                            ; relative positioning
+    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    TURN_OFF_HEATERS
+    M107                           ; turn off fan
+    G1 Z2 F3000                    ; move nozzle up 2mm
+    G90                            ; absolute positioning
+    G0  X125 Y250 F3600            ; park nozzle at rear
+    BED_MESH_CLEAR
+
+## 	Thermistor Types
+##   "EPCOS 100K B57560G104F"
+##   "ATC Semitec 104GT-2"
+##   "NTC 100K beta 3950"
+##   "Honeywell 100K 135-104LAG-J01"
+##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
+##   "AD595"
+##   "PT100 INA826"


### PR DESCRIPTION
Added a copied version of the example klipper printer.cfg vor V2.2 of the Spider.

I have tested this version with my v2.2 board.

- Changed bed heater pin to adapt for added thermistors (TB -> PB0)
- Changed fan pins for FAN0 and FAN1
